### PR TITLE
Fix Users seeder by matching database fields (first and last name)

### DIFF
--- a/api-man/database/seeds/DatabaseSeeder.php
+++ b/api-man/database/seeds/DatabaseSeeder.php
@@ -1,16 +1,37 @@
 <?php
 
 use Illuminate\Database\Seeder;
+use TCG\Voyager\Traits\Seedable;
 
 class DatabaseSeeder extends Seeder
 {
-    /**
-     * Run the database seeds.
-     *
-     * @return void
-     */
+  use Seedable;
+
+  protected $seedersPath = __DIR__.'/';
+
+  /**
+   * Run the database seeds.
+   *
+   * @return void
+   */
+
     public function run()
     {
-        // $this->call(UsersTableSeeder::class);
+
+      $this->seed('DataTypesTableSeeder');
+      $this->seed('DataRowsTableSeeder');
+      $this->seed('MenusTableSeeder');
+      $this->seed('MenuItemsTableSeeder');
+      $this->seed('RolesTableSeeder');
+      $this->seed('PermissionsTableSeeder');
+      $this->seed('PermissionRoleTableSeeder');
+      $this->seed('SettingsTableSeeder');
+
+      //dummy data
+      $this->seed('CategoriesTableSeeder');
+      $this->seed('UsersTableSeeder');
+      $this->seed('PostsTableSeeder');
+      $this->seed('PagesTableSeeder');
+      $this->seed('TranslationsTableSeeder');
     }
 }

--- a/api-man/database/seeds/UsersTableSeeder.php
+++ b/api-man/database/seeds/UsersTableSeeder.php
@@ -17,9 +17,10 @@ class UsersTableSeeder extends Seeder
             $role = Role::where('name', 'admin')->firstOrFail();
 
             User::create([
-                'name'           => 'Admin',
+                'nume'           => 'Admin',
+                'prenume'        => 'Adminescu',
                 'email'          => 'admin@admin.com',
-                'password'       => bcrypt('password'),
+                'parola'         => bcrypt('password'),
                 'remember_token' => str_random(60),
                 'role_id'        => $role->id,
             ]);


### PR DESCRIPTION
Additionally, force seeders order triggered on `php artisan db:seed` command by 
including them in the default `DatabaseSeeder.php`